### PR TITLE
Support hawk options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -80,7 +80,7 @@ internals.oz = function (server, options) {
     var scheme = {
         authenticate: function (request, reply) {
 
-            Oz.server.authenticate(request.raw.req, settings.oz.encryptionPassword, {}, function (err, credentials, artifacts) {
+            Oz.server.authenticate(request.raw.req, settings.oz.encryptionPassword, { hawk : settings.oz.hawk }, function (err, credentials, artifacts) {
 
                 if (err) {
                     return reply(Boom.unauthorized(err, null, { credentials: credentials }));

--- a/lib/index.js
+++ b/lib/index.js
@@ -80,7 +80,7 @@ internals.oz = function (server, options) {
     var scheme = {
         authenticate: function (request, reply) {
 
-            Oz.server.authenticate(request.raw.req, settings.oz.encryptionPassword, { hawk : settings.oz.hawk }, function (err, credentials, artifacts) {
+            Oz.server.authenticate(request.raw.req, settings.oz.encryptionPassword, { hawk: settings.oz.hawk }, function (err, credentials, artifacts) {
 
                 if (err) {
                     return reply(Boom.unauthorized(err, null, { credentials: credentials }));

--- a/test/index.js
+++ b/test/index.js
@@ -81,7 +81,18 @@ describe('Scarecrow', function () {
 
             // Add a protected resource
 
-            server.route({ path: '/protected', method: 'GET', config: { auth: { entity: 'user' }, handler: function (request, reply) { reply(request.auth.credentials.user + ' your in!'); } } });
+            server.route({
+              path: '/protected',
+              method: 'GET',
+              config: {
+                auth: {
+                  entity: 'user'
+                },
+                handler: function (request, reply) {
+                  reply(request.auth.credentials.user + ' your in!');
+                }
+              }
+            });
 
             // The app requests an app ticket using Hawk authentication
 
@@ -200,7 +211,18 @@ describe('Scarecrow', function () {
 
             // Add a protected resource
 
-            server.route({ path: '/protected', method: 'GET', config: { auth: { entity: 'user' }, handler: function (request, reply) { reply(request.auth.credentials.user + ' your in!'); } } });
+            server.route({
+              path: '/protected',
+              method: 'GET',
+              config: {
+                auth: {
+                  entity: 'user'
+                },
+                handler: function (request, reply) {
+                  reply(request.auth.credentials.user + ' your in!');
+                }
+              }
+            });
 
             // The app requests an app ticket using Hawk authentication
 

--- a/test/index.js
+++ b/test/index.js
@@ -89,7 +89,9 @@ describe('Scarecrow', function () {
                   entity: 'user'
                 },
                 handler: function (request, reply) {
-                  reply(request.auth.credentials.user + ' your in!');
+
+                    reply(request.auth.credentials.user + ' your in!');
+
                 }
               }
             });
@@ -219,7 +221,9 @@ describe('Scarecrow', function () {
                   entity: 'user'
                 },
                 handler: function (request, reply) {
-                  reply(request.auth.credentials.user + ' your in!');
+
+                    reply(request.auth.credentials.user + ' your in!');
+
                 }
               }
             });


### PR DESCRIPTION
The hawk options were not passed in the `Oz.server.authenticate` method. I have to modify it to make my (nginx + ssl + hapi) environment work.

```js
server.auth.strategy('oz', 'oz', true, {
      oz: {
        encryptionPassword: config.ozPassword,
        loadAppFunc: Auth.getLoadAppFunc(db),
        loadGrantFunc: Auth.getLoadGrandFunc(db),
        hawk: {
          port: config.server.api.tls ? 443 : null
        }
      },
      urls: {
        app: '/auth/app',
        reissue: '/auth/reissue',
        rsvp: '/auth/rsvp'
      }
    });
```